### PR TITLE
Fix error from rewrite for form field validation.

### DIFF
--- a/engine/tg_helpers/validation_helper.php
+++ b/engine/tg_helpers/validation_helper.php
@@ -70,7 +70,7 @@ class Validation_helper {
                 $this->valid_time($validation_data);
                 break;
             case 'unique':
-                $inner_value = (isset($validation_data['inner_value'])) ? $inner_value : 0;
+                $inner_value = $validation_data['inner_value'] ?? 0;
                 $this->unique($validation_data, $inner_value);
                 break;
             default:


### PR DESCRIPTION
Originally, $inner_value has been set by using extract() on the $validation_data array. Now, the extract() method call is removed, so $inner_value is undefined.