### PR TITLE
url_title() fix for non-Latin characters and removed a deprecated method, utf8_encode() introduced in PHP 8.2

### DIFF
--- a/modules/doco/assets/api.json
+++ b/modules/doco/assets/api.json
@@ -1,0 +1,134 @@
+{
+  "Remember Positions": {
+    "url_segments": "doco/remember_positions",
+    "request_type": "POST",
+    "description": "Remember positions of some child nodes",
+    "enableParams": true,
+    "authorization":{  
+        "roles": [
+            "admin"
+        ]
+    }
+  },
+  "Get": {
+    "url_segments": "api/get/doco",
+    "request_type": "GET",
+    "description": "Fetch rows from table",
+    "enableParams": true,
+    "authorization":{  
+        "roles": [
+            "admin"
+        ]
+    }
+  },
+  "Get By Post": {
+    "url_segments": "api/get/doco",
+    "request_type": "POST",
+    "description": "Fetch rows from table using POST request.",
+    "enableParams": true,
+    "authorization":{  
+        "roles": [
+            "admin"
+        ]
+    }
+  },
+  "Find One": {
+    "url_segments": "api/get/doco/{id}",
+    "request_type": "GET",
+    "description": "Fetch one row",
+    "required_fields": [
+      {
+        "name": "id",
+        "label": "ID"
+      }
+    ]
+  },
+  "Exists": {
+    "url_segments": "api/exists/doco/{id}",
+    "request_type": "GET",
+    "description": "Check if instance exists",
+    "required_fields": [
+      {
+        "name": "id",
+        "label": "ID"
+      }
+    ]
+  },
+  "Count": {
+    "url_segments": "api/count/doco",
+    "request_type": "GET",
+    "description": "Count number of records",
+    "enableParams": true
+  },
+  "Count By Post": {
+    "url_segments": "api/count/doco",
+    "request_type": "POST",
+    "description": "Count number of records using POST request",
+    "enableParams": true,
+    "authorization":{  
+        "roles": [
+            "admin"
+        ]
+    }
+  },
+  "Create": {
+    "url_segments": "api/create/doco",
+    "request_type": "POST",
+    "description": "Insert database record",
+    "enableParams": true,
+    "authorization":{  
+        "roles": [
+            "admin"
+        ]
+    },
+    "beforeHook": "_prep_input",
+    "afterHook": "_fetch_item_details"
+  },
+  "Insert Batch": {
+    "url_segments": "api/batch/doco",
+    "request_type": "POST",
+    "description": "Insert multiple records",
+    "enableParams": true
+  },
+  "Update": {
+    "url_segments": "api/update/doco/{id}",
+    "request_type": "PUT",
+    "description": "Update a database record",
+    "enableParams": true,
+    "required_fields": [
+      {
+        "name": "id",
+        "label": "ID"
+      }
+    ],
+    "authorization":{  
+        "roles": [
+            "admin"
+        ]
+    },
+    "beforeHook": "_prep_input",
+    "afterHook": "_fetch_item_details"
+  },
+  "Destroy": {
+    "url_segments": "api/destroy/doco",
+    "request_type": "DELETE",
+    "description": "Delete row or rows",
+    "enableParams": true
+  },
+  "Delete One": {
+    "url_segments": "api/delete/doco/{id}",
+    "request_type": "DELETE",
+    "description": "Delete one row",
+    "required_fields": [
+      {
+        "name": "id",
+        "label": "ID"
+      }
+    ],
+    "authorization":{  
+        "roles": [
+            "admin"
+        ]
+    }
+  }
+}

--- a/modules/doco/controllers/Doco.php
+++ b/modules/doco/controllers/Doco.php
@@ -1,0 +1,6 @@
+<?php
+class Doco extends Trongate {
+
+
+
+}


### PR DESCRIPTION
There are 3 reasons for this pull request:

1. Removed an ugly PHP 8.2 deprecated method [utf8_encode()](https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated) - _thanks very much PHP Foundation!_ 😟 [#StopBreakingPHP](https://trongate.io/news/display/TWN4GR/its-time-for-the-php-foundation-to-stopbreakingphp)
2. I pulled in this [help_bar fix by framex](https://trongate.io/help_bar/thread/h7W9QyPcsx69) who added full support for non-Latin characters, where previously they were stripped from the input string.
3. I also added a PHP DocBlock to document the method for Intellisense.  If you like them DC, I will proceed to add more throughout the framework as previously discussed and mentioned in [this help_bar post](https://trongate.io/help_bar/thread/SYeCjtEXc47z).  As you will notice, we can add links to the official documents on [trongate.io](https://trongate.io/docs) and other tags to make the in-code-documentation a delight to use.

All other changes in this file are because I'm using Prettier which cleans up the PHP code to k&r standards.

Cheers,
Simon