### PR TITLE
Replaced insecure token generator with a secure one

### DIFF
--- a/modules/trongate_tokens/controllers/Trongate_tokens.php
+++ b/modules/trongate_tokens/controllers/Trongate_tokens.php
@@ -272,14 +272,15 @@ class Trongate_tokens extends Trongate {
         return $random_string;
     }
 
-    function _generate_rand_str() {
-        $token_length = 32;
-        $characters = '-_0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-        $random_string = '';
-        for ($i = 0; $i < $token_length; $i++) {
-            $random_string .= $characters[mt_rand(0, strlen($characters) - 1)];
+    function _generate_rand_str($length = 32) {
+        $token_length = ($length / 2);
+
+        try {
+            $random_bytes = random_bytes($token_length); # (PHP > 7.0)
+        } catch (\Exception) {
+            exit("Appropriate source of randomness cannot be found");
         }
-        return $random_string;
+        return bin2hex($random_bytes);
     }
 
     function regenerate() {


### PR DESCRIPTION
Replaced the insecure random string generator located within the Trongate tokens module with a cryptographically secure one. This closes the doors for some vulnerabilities that rely upon these insecure generators.

The code I committed works from PHP 7.0 and up. A fallback that uses the less secure 'openssl_random_pseudo_bytes' function can be implemented if required, although I would not recommend this.

More information about it: https://owasp.org/www-community/vulnerabilities/Insecure_Randomness