### PR TITLE
No need for an else clause, just initialize $user_level before if statement.

### DIFF
--- a/modules/trongate_users/trongate_user_levels/controllers/Trongate_user_levels.php
+++ b/modules/trongate_users/trongate_user_levels/controllers/Trongate_user_levels.php
@@ -19,7 +19,7 @@ class Trongate_user_levels extends Trongate {
         $data['user_id'] = $user_id;
         $result = $this->model->query_bind($sql, $data, 'array');
         
-        $user_level = $result[0]['user_level'] ?? '';
+        $user_level = $result[0]['level_title'] ?? '';
 
         return $user_level;
     }

--- a/modules/trongate_users/trongate_user_levels/controllers/Trongate_user_levels.php
+++ b/modules/trongate_users/trongate_user_levels/controllers/Trongate_user_levels.php
@@ -19,10 +19,7 @@ class Trongate_user_levels extends Trongate {
         $data['user_id'] = $user_id;
         $result = $this->model->query_bind($sql, $data, 'array');
         
-        $user_level = '';
-        if (isset($result[0])) {
-            $user_level = $result[0]['level_title'];
-        } 
+        $user_level = $result[0]['user_level'] ?? '';
 
         return $user_level;
     }

--- a/modules/trongate_users/trongate_user_levels/controllers/Trongate_user_levels.php
+++ b/modules/trongate_users/trongate_user_levels/controllers/Trongate_user_levels.php
@@ -18,12 +18,11 @@ class Trongate_user_levels extends Trongate {
 
         $data['user_id'] = $user_id;
         $result = $this->model->query_bind($sql, $data, 'array');
-
+        
+        $user_level = '';
         if (isset($result[0])) {
             $user_level = $result[0]['level_title'];
-        } else {
-            $user_level = '';
-        }
+        } 
 
         return $user_level;
     }


### PR DESCRIPTION
There is no need for an else clause here, we can just initialize the $user_level variable before the if statement to $user_level = '';

less code, more readable?