### PR TITLE
Add ID Parameter for Deletion in delete_one() Function

### DIFF
--- a/engine/Core.php
+++ b/engine/Core.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Class Core
  * Manages the serving of assets for the Trongate framework.
@@ -31,7 +32,7 @@ class Core {
      */
     private function serve_vendor_asset(): void {
         $vendor_file_path = explode('/vendor/', ASSUMED_URL)[1];
-        $vendor_file_path = '../vendor/'.$vendor_file_path;
+        $vendor_file_path = '../vendor/' . $vendor_file_path;
         if (file_exists($vendor_file_path)) {
             if (strpos($vendor_file_path, '.css')) {
                 $content_type = 'text/css';
@@ -39,11 +40,11 @@ class Core {
                 $content_type = 'text/plain';
             }
 
-            header('Content-type: '.$content_type);
+            header('Content-type: ' . $content_type);
             $contents = file_get_contents($vendor_file_path);
             echo $contents;
             die();
-        }else{
+        } else {
             die('Vendor file not found.');
         }
     }
@@ -61,17 +62,17 @@ class Core {
 
             if (is_numeric($pos)) {
                 $target_module = str_replace(MODULE_ASSETS_TRIGGER, '', $url_segment_value);
-                $file_name = $url_segments[count($url_segments)-1];
+                $file_name = $url_segments[count($url_segments) - 1];
 
                 $target_dir = '';
-                for ($i=$url_segment_key+1; $i < count($url_segments)-1; $i++) {
-                    $target_dir.= $url_segments[$i];
-                    if ($i<count($url_segments)-2) {
-                        $target_dir.= '/';
+                for ($i = $url_segment_key + 1; $i < count($url_segments) - 1; $i++) {
+                    $target_dir .= $url_segments[$i];
+                    if ($i < count($url_segments) - 2) {
+                        $target_dir .= '/';
                     }
                 }
 
-                $asset_path = '../modules/'.strtolower($target_module).'/assets/'.$target_dir.'/'.$file_name;
+                $asset_path = '../modules/' . strtolower($target_module) . '/assets/' . $target_dir . '/' . $file_name;
 
                 if (file_exists($asset_path)) {
                     $content_type = mime_content_type($asset_path);
@@ -87,20 +88,19 @@ class Core {
                         if (is_numeric($pos2)) {
                             $content_type = 'text/javascript';
                         }
-
                     }
 
                     if ($content_type === 'image/svg') {
-                        $content_type.= '+xml';
+                        $content_type .= '+xml';
                     }
 
                     //make sure not a PHP file or api.json
-                    if((is_numeric(strpos($content_type, 'php'))) || ($file_name === 'api.json')) {
+                    if ((is_numeric(strpos($content_type, 'php'))) || ($file_name === 'api.json')) {
                         http_response_code(422);
                         die();
                     }
 
-                    header('Content-type: '.$content_type);
+                    header('Content-type: ' . $content_type);
                     $contents = file_get_contents($asset_path);
                     echo $contents;
                     die();
@@ -109,7 +109,6 @@ class Core {
                 }
             }
         }
-
     }
 
     /**
@@ -132,32 +131,31 @@ class Core {
 
         $bits = explode('-', $target_str);
 
-        if (count($bits)==2) {
-            if (strlen($bits[1])>0) {
+        if (count($bits) == 2) {
+            if (strlen($bits[1]) > 0) {
                 $parent_module = $bits[0];
                 $child_module = $bits[1];
 
-                $asset_path = str_replace($target_str, $parent_module.'/'.$child_module, $asset_path);
+                $asset_path = str_replace($target_str, $parent_module . '/' . $child_module, $asset_path);
                 if (file_exists($asset_path)) {
 
                     $content_type = mime_content_type($asset_path);
 
-                    if ($content_type === 'text/plain'|| $content_type === 'text/html') {
+                    if ($content_type === 'text/plain' || $content_type === 'text/html') {
                         $pos2 = strpos($file_name, '.css');
                         if (is_numeric($pos2)) {
                             $content_type = 'text/css';
                         }
-                         $pos2 = strpos($file_name, '.js');
+                        $pos2 = strpos($file_name, '.js');
                         if (is_numeric($pos2)) {
                             $content_type = 'text/javascript';
                         }
                     }
 
-                    header('Content-type: '.$content_type);
+                    header('Content-type: ' . $content_type);
                     $contents = file_get_contents($asset_path);
                     echo $contents;
                     die();
-
                 }
             }
         }
@@ -170,20 +168,19 @@ class Core {
      * @return void
      */
     private function attempt_sql_transfer(string $controller_path): void {
-        $ditch = 'controllers/'.$this->current_controller.'.php';
+        $ditch = 'controllers/' . $this->current_controller . '.php';
         $dir_path = str_replace($ditch, '', $controller_path);
 
         $files = array();
-        foreach (glob($dir_path."*.sql") as $file) {
+        foreach (glob($dir_path . "*.sql") as $file) {
             $file = str_replace($controller_path, '', $file);
             $files[] = $file;
         }
 
-        if (count($files)>0) {
+        if (count($files) > 0) {
             require_once('tg_transferer/index.php');
             die();
         }
-
     }
 
     /**
@@ -196,7 +193,7 @@ class Core {
 
         if (isset($segments[1])) {
             $module_with_no_params = explode('?', $segments[1])[0];
-            $this->current_module = strtolower($module_with_no_params);
+            $this->current_module = !empty($module_with_no_params) ? strtolower($module_with_no_params) : $this->current_module;
             $this->current_controller = ucfirst($this->current_module);
 
             if (defined('TRONGATE_PAGES_TRIGGER') && $segments[1] === TRONGATE_PAGES_TRIGGER) {
@@ -207,7 +204,7 @@ class Core {
 
         if (isset($segments[2])) {
             $method_with_no_params = explode('?', $segments[2])[0];
-            $this->current_method = strtolower($method_with_no_params);
+            $this->current_method = !empty($method_with_no_params) ? strtolower($method_with_no_params) : $this->current_method;
 
             if (substr($this->current_method, 0, 1) === '_') {
                 $this->draw_error_page();
@@ -215,7 +212,8 @@ class Core {
         }
 
         if (isset($segments[3])) {
-            $this->current_value = explode('?', $segments[3])[0];
+            $no_query_params = explode('?', $segments[3])[0];
+            $this->current_value = !empty($no_query_params) ? $no_query_params : $this->current_value;
         }
 
         $controller_path = '../modules/' . $this->current_module . '/controllers/' . $this->current_controller . '.php';
@@ -337,13 +335,13 @@ class Core {
     private function attempt_init_child_controller(string $controller_path): string {
         $bits = explode('-', $this->current_controller);
 
-        if (count($bits)==2) {
-            if (strlen($bits[1])>0) {
+        if (count($bits) == 2) {
+            if (strlen($bits[1]) > 0) {
 
                 $parent_module = strtolower($bits[0]);
                 $child_module = strtolower($bits[1]);
                 $this->current_controller = ucfirst($bits[1]);
-                $controller_path = '../modules/'.$parent_module.'/'.$child_module.'/controllers/'.ucfirst($bits[1]).'.php';
+                $controller_path = '../modules/' . $parent_module . '/' . $child_module . '/controllers/' . ucfirst($bits[1]) . '.php';
 
                 if (file_exists($controller_path)) {
                     return $controller_path;
@@ -357,10 +355,10 @@ class Core {
             $this->current_module = $intercept_bits[0];
             $this->current_controller = ucfirst($intercept_bits[0]);
             $this->current_method = $intercept_bits[1];
-            $controller_path = '../modules/'.$this->current_module.'/controllers/'.$this->current_controller.'.php';
-            if(file_exists($controller_path)) {
+            $controller_path = '../modules/' . $this->current_module . '/controllers/' . $this->current_controller . '.php';
+            if (file_exists($controller_path)) {
                 return $controller_path;
-            }        
+            }
         }
 
         $this->draw_error_page();
@@ -375,5 +373,4 @@ class Core {
         load('error_404');
         die(); //end of the line (all possible scenarios tried)
     }
-
 }

--- a/engine/Standard_endpoints.php
+++ b/engine/Standard_endpoints.php
@@ -23,7 +23,7 @@ class Standard_endpoints extends Trongate {
             // Get the desired HTTP method from the X-HTTP-Method-Override header
             $request_type = strtoupper($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE']);
         }
-   
+
         return $request_type;
     }
 
@@ -45,7 +45,7 @@ class Standard_endpoints extends Trongate {
         }
     }
 
-    public function get($return_row_count=false) { //GET
+    public function get($return_row_count = false) { //GET
         //get the endpoint from the api.json file (and make sure allowed!)
         $endpoint_name =  $return_row_count === true ? 'Count' : 'Get';
         $table_name = segment(1) === 'api' ? segment(3) : segment(1);
@@ -60,7 +60,7 @@ class Standard_endpoints extends Trongate {
             $input = $this->attempt_invoke_before_hook($table_name, $before_hook, $input);
         }
 
-        $standard_query = 'SELECT * FROM '.$table_name;
+        $standard_query = 'SELECT * FROM ' . $table_name;
         $rows = $this->fetch_rows($standard_query, $input['params']);
 
         $output['token'] = $input['token'];
@@ -77,11 +77,11 @@ class Standard_endpoints extends Trongate {
         die();
     }
 
-    public function search($return_row_count=false) { //POST
+    public function search($return_row_count = false) { //POST
         $request_type = $this->get_request_type();
-        if($request_type !== 'POST') {
+        if ($request_type !== 'POST') {
             http_response_code(400);
-            die();            
+            die();
         }
 
         $table_name = segment(1) === 'api' ? segment(3) : segment(1);
@@ -97,7 +97,7 @@ class Standard_endpoints extends Trongate {
             $input = $this->attempt_invoke_before_hook($table_name, $before_hook, $input);
         }
 
-        $standard_query = 'SELECT * FROM '.$table_name;
+        $standard_query = 'SELECT * FROM ' . $table_name;
         $rows = $this->fetch_rows($standard_query, $input['params']);
 
         $output['token'] = $input['token'];
@@ -156,7 +156,6 @@ class Standard_endpoints extends Trongate {
         } else {
             $this->api_manager_error(400, 'Non-numeric update ID!');
         }
-
     }
 
     public function exists() { //GET
@@ -195,7 +194,6 @@ class Standard_endpoints extends Trongate {
         http_response_code($output['code']);
         echo $output['body'];
         die();
-
     }
 
     public function count() { //GET or POST
@@ -222,7 +220,7 @@ class Standard_endpoints extends Trongate {
         unset($input['target_endpoint']);
 
         //make sure params have been posted
-        if(count($input['params']) == 0) {
+        if (count($input['params']) == 0) {
             $this->api_manager_error(400, 'No posted data!');
         }
 
@@ -232,19 +230,19 @@ class Standard_endpoints extends Trongate {
 
         $columns_exist_result = $this->make_sure_columns_exist($table_name, $input['params']);
 
-        if($columns_exist_result !== true) {
+        if ($columns_exist_result !== true) {
             $this->api_manager_error(400, $columns_exist_result);
-        }  
+        }
 
         //attempt insert new record
         try {
             $new_id = $this->model->insert($input['params'], $table_name);
             $new_record_obj = $this->model->get_where($new_id, $table_name);
-           
+
             $output['token'] = $input['token'];
             $output['code'] = 200;
             $output['body'] = json_encode($new_record_obj);
-            
+
             if ($after_hook !== '') {
                 $output = $this->attempt_invoke_after_hook($table_name, $after_hook, $output);
             }
@@ -253,19 +251,17 @@ class Standard_endpoints extends Trongate {
             http_response_code($output['code']);
             echo $output['body'];
             die();
-
         } catch (Exception $e) {
             $this->api_manager_error(400, $e);
         }
-
     }
 
-    function make_sure_columns_exist($table_name, $params, $valid_columns=null) {
+    function make_sure_columns_exist($table_name, $params, $valid_columns = null) {
 
-        if(!isset($valid_columns)) {
+        if (!isset($valid_columns)) {
             $valid_columns = $this->get_all_columns($table_name);
         }
-        
+
         $invalid_columns = [];
         foreach ($params as $column => $value) {
             if (!in_array($column, $valid_columns)) {
@@ -285,13 +281,13 @@ class Standard_endpoints extends Trongate {
 
     private function get_all_columns($table) {
         $columns = [];
-        $sql = 'describe '.$table;
+        $sql = 'describe ' . $table;
         $rows = $this->model->query($sql, 'array');
         foreach ($rows as $row) {
             $columns[] = $row['Field'];
         }
 
-        return $columns;   
+        return $columns;
     }
 
     public function insert() { // BATCH INSERT!
@@ -312,7 +308,7 @@ class Standard_endpoints extends Trongate {
         //fetch the posted data
         $post = trim(file_get_contents('php://input'));
 
-        if($post === '') {
+        if ($post === '') {
             $this->api_manager_error(400, 'No posted data!');
         }
 
@@ -321,7 +317,7 @@ class Standard_endpoints extends Trongate {
             $this->api_manager_error(400, 'Invalid format: Not an array of objects!');
         }
 
-        if(count($posted_items) === 0) {
+        if (count($posted_items) === 0) {
             $this->api_manager_error('400', 'No posted data!');
         }
 
@@ -333,13 +329,12 @@ class Standard_endpoints extends Trongate {
 
         //loop through the posted data and make sure all of the columns exist on the table
         $valid_columns = $this->get_all_columns($table_name);
-        foreach($input['params'] as $posted_item) {
+        foreach ($input['params'] as $posted_item) {
             $columns_exist_result = $this->make_sure_columns_exist($table_name, $posted_item);
 
-            if($columns_exist_result !== true) {
+            if ($columns_exist_result !== true) {
                 $this->api_manager_error(400, $columns_exist_result);
-            }            
-
+            }
         }
 
         //attempt batch insert records
@@ -348,7 +343,7 @@ class Standard_endpoints extends Trongate {
             $row_count = $this->model->insert_batch($table_name, $input['params']);
             $output['body'] = $row_count;
             $output['code'] = 200;
-            
+
             if ($after_hook !== '') {
                 $output = $this->attempt_invoke_after_hook($table_name, $after_hook, $output);
             }
@@ -357,11 +352,9 @@ class Standard_endpoints extends Trongate {
             http_response_code($output['code']);
             echo $output['body'];
             die();
-
         } catch (Exception $e) {
             $this->api_manager_error(400, $e);
         }
-
     }
 
     public function update() { //POST or PUT
@@ -385,7 +378,7 @@ class Standard_endpoints extends Trongate {
         unset($input['target_endpoint']);
 
         //make sure params have been posted
-        if(count($input['params']) == 0) {
+        if (count($input['params']) == 0) {
             $this->api_manager_error(400, 'No posted data!');
         }
 
@@ -395,7 +388,7 @@ class Standard_endpoints extends Trongate {
 
         $columns_exist_result = $this->make_sure_columns_exist($table_name, $input['params']);
 
-        if($columns_exist_result !== true) {
+        if ($columns_exist_result !== true) {
             $this->api_manager_error(400, $columns_exist_result);
         }
 
@@ -404,11 +397,11 @@ class Standard_endpoints extends Trongate {
             unset($input['params']['id']);
             $this->model->update($update_id, $input['params'], $table_name);
             $record_obj = $this->model->get_where($update_id, $table_name);
-           
+
             $output['token'] = $input['token'];
             $output['code'] = 200;
             $output['body'] = json_encode($record_obj);
-            
+
             if ($after_hook !== '') {
                 $output = $this->attempt_invoke_after_hook($table_name, $after_hook, $output);
             }
@@ -417,11 +410,9 @@ class Standard_endpoints extends Trongate {
             http_response_code($output['code']);
             echo $output['body'];
             die();
-
         } catch (Exception $e) {
             $this->api_manager_error(400, $e);
         }
-
     }
 
     public function destroy() { //POST or DELETE
@@ -445,12 +436,12 @@ class Standard_endpoints extends Trongate {
             $input = $this->attempt_invoke_before_hook($table_name, $before_hook, $input);
         }
 
-        $standard_query = 'SELECT * FROM '.$table_name;
+        $standard_query = 'SELECT * FROM ' . $table_name;
         $rows = $this->fetch_rows($standard_query, $input['params']);
 
         // Build an array of items to go, based on 'id'
         $update_ids = [];
-        foreach($rows as $row) {
+        foreach ($rows as $row) {
             $update_ids[] = $row->id;
         }
 
@@ -466,7 +457,7 @@ class Standard_endpoints extends Trongate {
             // Convert the array of update IDs to a comma-separated string
             $update_ids_str = implode(',', $update_ids);
 
-            if(count($update_ids)>0) {
+            if (count($update_ids) > 0) {
                 // Build the SQL query to delete rows from the table where 'id' values match those in the array
                 $sql = "DELETE FROM $table_name WHERE id IN ({$update_ids_str})";
                 $this->model->query($sql);
@@ -474,7 +465,7 @@ class Standard_endpoints extends Trongate {
 
             $output['token'] = $input['token'];
             $output['code'] = 200;
-            $output['body'] = count($update_ids);  
+            $output['body'] = count($update_ids);
 
             if ($after_hook !== '') {
                 $output = $this->attempt_invoke_after_hook($table_name, $after_hook, $output);
@@ -483,12 +474,10 @@ class Standard_endpoints extends Trongate {
             $output = $this->clean_output($output);
             http_response_code($output['code']);
             echo $output['body'];
-            die();  
-
-         } catch (Exception $e) {
+            die();
+        } catch (Exception $e) {
             $this->api_manager_error(400, $e);
         }
-
     }
 
     public function delete_one() { //DELETE
@@ -496,7 +485,7 @@ class Standard_endpoints extends Trongate {
         $target_segment = (segment(1) === 'api') ? 4 : 2;
         $update_id = intval(segment($target_segment));
 
-        if($update_id <= 0) {
+        if ($update_id <= 0) {
             $this->api_manager_error(400, 'Invalid update ID!');
         }
 
@@ -516,12 +505,13 @@ class Standard_endpoints extends Trongate {
         unset($input['target_endpoint']);
 
         if ($before_hook !== '') {
+            $input['params']['id'] = $update_id; //set id to delete
             $input = $this->attempt_invoke_before_hook($table_name, $before_hook, $input);
         }
 
         $record_obj = $this->model->get_where($update_id, $table_name);
 
-        if($record_obj === false) {
+        if ($record_obj === false) {
             http_response_code(422);
             echo 'false';
             die();
@@ -530,11 +520,11 @@ class Standard_endpoints extends Trongate {
         //attempt delete record
         try {
             $this->model->delete($update_id, $table_name);
-           
+
             $output['token'] = $input['token'];
             $output['code'] = 200;
             $output['body'] = 'true';
-            
+
             if ($after_hook !== '') {
                 $output = $this->attempt_invoke_after_hook($table_name, $after_hook, $output);
             }
@@ -543,20 +533,18 @@ class Standard_endpoints extends Trongate {
             http_response_code($output['code']);
             echo $output['body'];
             die();
-
         } catch (Exception $e) {
             $this->api_manager_error(400, $e);
         }
-
     }
 
     private function attempt_invoke_before_hook($table_name, $before_hook, $input) {
-        $input = Modules::run($table_name.'/'.$before_hook, $input);
+        $input = Modules::run($table_name . '/' . $before_hook, $input);
         return $input;
     }
 
     private function attempt_invoke_after_hook($table_name, $after_hook, $output) {
-        $output = Modules::run($table_name.'/'.$after_hook, $output);
+        $output = Modules::run($table_name . '/' . $after_hook, $output);
         return $output;
     }
 
@@ -569,16 +557,16 @@ class Standard_endpoints extends Trongate {
         $where_clause = $where_data['where_clause'];
         $params = $where_data['params'];
 
-        if($where_clause !== '') {
-            $sql.= ' '.$where_clause;
+        if ($where_clause !== '') {
+            $sql .= ' ' . $where_clause;
         }
 
-        if($order_by_clause !== '') {
-            $sql.= ' '.$order_by_clause;
+        if ($order_by_clause !== '') {
+            $sql .= ' ' . $order_by_clause;
         }
 
-        if($limit_offset_clause !== '') {
-            $sql.= ' '.$limit_offset_clause;
+        if ($limit_offset_clause !== '') {
+            $sql .= ' ' . $limit_offset_clause;
         }
 
         try {
@@ -595,10 +583,10 @@ class Standard_endpoints extends Trongate {
         $counter = 0;
         $ignore_keys = array('orderBy', 'order_by', 'limit', 'offset', 'ixd');
         $where_clause = '';
-        foreach($submitted_params as $key => $value) {
+        foreach ($submitted_params as $key => $value) {
             $key_bits = explode(' ', trim($key));
             //ignore limit, offset etc...
-            if(in_array($key_bits[0], $ignore_keys)) {
+            if (in_array($key_bits[0], $ignore_keys)) {
                 continue;
             }
 
@@ -611,16 +599,16 @@ class Standard_endpoints extends Trongate {
 
             $column = $key_bits[0];
 
-            if(count($key_bits)>1) {
-                $last_bit = $key_bits[count($key_bits)-1];
+            if (count($key_bits) > 1) {
+                $last_bit = $key_bits[count($key_bits) - 1];
                 $operator = ($last_bit === '!') ? '!=' : $operator = $last_bit;
             } else {
                 $operator = '=';
             }
 
             $counter++;
-            $property_name = 'arg'.$counter;
-            $where_clause.= $conjunction.' '.$column.$operator.'? ';
+            $property_name = 'arg' . $counter;
+            $where_clause .= $conjunction . ' ' . $column . $operator . '? ';
             $params[] = $value;
         }
 
@@ -630,9 +618,9 @@ class Standard_endpoints extends Trongate {
     }
 
     private function extract_order_by_clause($submitted_params) {
-        foreach($submitted_params as $key => $value) {
-            if($key === 'orderBy' OR $key === 'order_by') {
-                $order_by_clause = 'ORDER BY '.$value;
+        foreach ($submitted_params as $key => $value) {
+            if ($key === 'orderBy' or $key === 'order_by') {
+                $order_by_clause = 'ORDER BY ' . $value;
                 return $order_by_clause;
             }
         }
@@ -685,9 +673,9 @@ class Standard_endpoints extends Trongate {
 
         $first_segment = remove_query_string(segment(1));
         $second_segment = remove_query_string(segment(2));
-        $ditch = $second_segment === '' ? BASE_URL.$first_segment : BASE_URL.$first_segment.'/';
+        $ditch = $second_segment === '' ? BASE_URL . $first_segment : BASE_URL . $first_segment . '/';
         $resource_path = str_replace($ditch, '', $current_url);
-        
+
         $segments = explode('/', $resource_path);
         foreach ($segments as &$segment) {
             if (is_numeric($segment)) {
@@ -704,17 +692,17 @@ class Standard_endpoints extends Trongate {
         $standard_endpoints = $this->get_standard_endpoints();
         $resource_path = str_replace('%7Bid%7D', '{id}', $resource_path);
 
-        foreach ($standard_endpoints as $i => $standard_endpoint) { 
+        foreach ($standard_endpoints as $i => $standard_endpoint) {
             $target_request_type =  $standard_endpoint['request_type'];
             $restful_identifier = $standard_endpoint['restful_identifier'];
-           
-            if(($resource_path === $restful_identifier) && ($request_type === $target_request_type)) {
+
+            if (($resource_path === $restful_identifier) && ($request_type === $target_request_type)) {
                 $target_endpoint_index = $i;
                 break;
             }
         }
 
-        if(!isset($target_endpoint_index)) {
+        if (!isset($target_endpoint_index)) {
             $target_endpoint_index = '';
         }
 
@@ -737,7 +725,7 @@ class Standard_endpoints extends Trongate {
 
         if ($endpoint_name === 'Search') {
             $input['target_endpoint'] = $endpoints[$endpoint_name] ?? false;
-            
+
             // If the 'Search' endpoint is not found, try 'Get By Post' as fallback
             if ($input['target_endpoint'] === false) {
                 $input['target_endpoint'] = $endpoints['Get By Post'] ?? false;
@@ -766,18 +754,17 @@ class Standard_endpoints extends Trongate {
 
         if (($enable_params === true) && ($endpoint_name !== 'Insert Batch')) {
 
-            if($request_type === 'GET') {
+            if ($request_type === 'GET') {
                 $query_params = $this->fetch_query_params_from_url();
-                $input['params']= $this->reduce_query_params($query_params);
+                $input['params'] = $this->reduce_query_params($query_params);
             } else {
                 //attemp get params from post
                 $query_params = $this->fetch_query_params_from_post();
-                $input['params']= $this->reduce_query_params($query_params);
+                $input['params'] = $this->reduce_query_params($query_params);
             }
-
         }
 
-        if(!isset($input['params'])) {
+        if (!isset($input['params'])) {
             $input['params'] = [];
         }
 
@@ -809,11 +796,11 @@ class Standard_endpoints extends Trongate {
         //attempt fetch user object from the token
         $trongate_user = $this->trongate_tokens->_get_user_obj($token);
 
-        if($trongate_user === false) {
+        if ($trongate_user === false) {
             // Test for aaa token
             $allowed = $this->test_for_aaa_token($token);
-            if($allowed === true) {
-               return $token; //aaa token submitted - access allowed
+            if ($allowed === true) {
+                return $token; //aaa token submitted - access allowed
             } else {
                 $this->api_manager_error(401, 'Invalid token.');
             }
@@ -838,13 +825,13 @@ class Standard_endpoints extends Trongate {
             }
         }
 
-        if(segment(1) === 'api') {
+        if (segment(1) === 'api') {
 
             //user id segment authorization (only for Trongate API paths!)
             if (isset($endpoint_auth_rules['userIdSegment'])) {
                 $target_value = segment($endpoint_auth_rules['userIdSegment']);
                 settype($target_value, 'int');
-                
+
                 if ($trongate_user_id === $target_value) {
                     return $token; //match for trongate_user_id on target segment
                 }
@@ -853,7 +840,7 @@ class Standard_endpoints extends Trongate {
             //user code segment authorization (only for Trongate API paths!)
             if (isset($endpoint_auth_rules['userCodeSegment'])) {
                 $target_value = segment($endpoint_auth_rules['userCodeSegment']);
-                
+
                 if ($trongate_user_code === $target_value) {
                     return $token; //match for trongate_user_code on target segment
                 }
@@ -867,7 +854,6 @@ class Standard_endpoints extends Trongate {
                 $this->run_user_owned_test($test_data); //true or false
                 return $token;
             }
-
         }
 
         //safety net
@@ -896,12 +882,11 @@ class Standard_endpoints extends Trongate {
             settype($trongate_user_id, 'int');
             settype($target_trongate_user_id, 'int');
 
-            if ($trongate_user_id === $target_trongate_user_id && ($trongate_user_id>0)) {
+            if ($trongate_user_id === $target_trongate_user_id && ($trongate_user_id > 0)) {
                 return; //match for user owned segment
             } else {
                 $this->api_manager_error(401, 'Invalid token.');
             }
-
         }
     }
 
@@ -912,9 +897,9 @@ class Standard_endpoints extends Trongate {
         $query_str_bits = explode('&', $query_str);
         $operators = $this->operators;
 
-        foreach($query_str_bits as $query_str_bit) {
+        foreach ($query_str_bits as $query_str_bit) {
             $row_data = $this->extract_query_param($query_str_bit, $operators);
-            if($row_data !== false) {
+            if ($row_data !== false) {
                 $query_params[] = $row_data;
             }
         }
@@ -928,35 +913,35 @@ class Standard_endpoints extends Trongate {
         //get posted params
         $post = file_get_contents('php://input');
 
-        if($post === '') {
+        if ($post === '') {
             return $query_params;
         }
 
         $posted_args = json_decode($post, true);
         $operators = $this->operators;
 
-        if(!isset($posted_args)) {
+        if (!isset($posted_args)) {
             $this->api_manager_error(400, 'Invalid JSON!');
         }
 
-        foreach($posted_args as $key => $value) {
+        foreach ($posted_args as $key => $value) {
             $key = str_replace('>=', ' >=', $key);
             $key = str_replace('<=', ' <=', $key);
             $key = str_replace('!', ' !', $key);
             $key = str_replace('<', ' <', $key);
             $key = str_replace('>', ' >', $key);
 
-            $unwanted_chars = array('or ', 'OR ' , '!', 'and ', 'AND ', '!=', '>', '<', '>=', '<=');
+            $unwanted_chars = array('or ', 'OR ', '!', 'and ', 'AND ', '!=', '>', '<', '>=', '<=');
             $key_string = $key;
             foreach ($unwanted_chars as $char) {
                 $key_string = str_replace($char, '', $key_string);
             }
 
             $row_data['key'] = trim($key_string);
-    
+
             //figure out what the operator is
             $key_bits = explode(' ', trim($key));
-            if(count($key_bits) === 1) {
+            if (count($key_bits) === 1) {
                 $row_data['operator'] = '=';
             } else {
                 $row_data['operator'] = '=';
@@ -964,17 +949,17 @@ class Standard_endpoints extends Trongate {
                 $operators_keys = array_keys($operators);
 
                 foreach ($operators_keys as $needle) {
-                        if (strpos($key, $needle) !== false) {
-                            $row_data['operator'] = $needle;
-                            break;
-                        }
+                    if (strpos($key, $needle) !== false) {
+                        $row_data['operator'] = $needle;
+                        break;
+                    }
                 }
             }
 
-            if(strlen($key)>3) {
+            if (strlen($key) > 3) {
                 $first_three = substr($key, 0, 3);
-                if(strtoupper($first_three === 'OR ')) {
-                    $row_data['key'] = 'OR '.$row_data['key'];
+                if (strtoupper($first_three === 'OR ')) {
+                    $row_data['key'] = 'OR ' . $row_data['key'];
                 }
             }
 
@@ -982,21 +967,21 @@ class Standard_endpoints extends Trongate {
             $query_params[] = $row_data;
         }
 
-        return $query_params;        
+        return $query_params;
     }
 
     private function extract_query_param($query_str_bit, $operators) {
         //build a bit list of all possible operators
-        foreach($operators as $operator_plain => $operator_encoded) {
+        foreach ($operators as $operator_plain => $operator_encoded) {
             $relevant_operator = $operator_encoded;
             $str_bits = explode($operator_encoded, $query_str_bit);
 
-            if(count($str_bits) !== 2) {
+            if (count($str_bits) !== 2) {
                 $str_bits = explode($operator_plain, $query_str_bit);
                 $relevant_operator = $operator_plain;
             }
 
-            if(count($str_bits) === 2) {
+            if (count($str_bits) === 2) {
                 $row_data['key'] = $str_bits[0];
                 $row_data['operator'] = $relevant_operator;
                 $row_data['value'] = $str_bits[1];
@@ -1009,23 +994,22 @@ class Standard_endpoints extends Trongate {
     function reduce_query_params($query_params) {
         //reduce query params to simple key/value pairs
         $params = [];
-        foreach($query_params as $query_param) {
+        foreach ($query_params as $query_param) {
             $param_key = $query_param['key'] ?? '';
             $param_operator = $query_param['operator'] ?? '';
             $param_value = $query_param['value'] ?? '';
 
-            if($param_operator === '=') {
+            if ($param_operator === '=') {
                 $key = $param_key;
             } else {
                 $param_operator = str_replace('!=', '!', $param_operator);
                 $param_operator = str_replace('%21=', '!', $param_operator);
                 $param_operator = str_replace('%3C', '<', $param_operator);
                 $param_operator = str_replace('%3E', '<', $param_operator);
-                $key = $param_key.' '.$param_operator;
+                $key = $param_key . ' ' . $param_operator;
             }
 
             $params[$key] = $param_value;
-
         }
         return $params;
     }


### PR DESCRIPTION
### Addressed a reported bug from [michidesign on the Help_bar](https://trongate.io/help_bar_threads/display/qj5gPGS6V6ELeCDK) regarding ineffective execution of the before hook.

The "delete_one()" method in "Standard_endpoints.php" was not sending an 'id' to delete in the passed '$input' array which was being checked in the "_make_sure_delete_allowed" method from the **Category Builder** module on [the Module Market](https://trongate.io/module-market).

This fix:
1. Ensures proper handling of subcategories, preventing the deletion of a parent category when subcategories exist.
2. Resolves the issue of subcategories remaining in the table without appearing in categories/manage after deleting a main category.
3. Enhances Category Builder reliability.