### PR TITLE
Fix type error when index is 0

### DIFF
--- a/modules/trongate_pages/controllers/Trongate_pages.php
+++ b/modules/trongate_pages/controllers/Trongate_pages.php
@@ -1174,19 +1174,13 @@ class Trongate_pages extends Trongate {
     /**
      * Set the number of items per page based on the selected index.
      *
-     * @param int $selected_index The selected index for the number of items per page.
-     *
      * @return void
      */
-    function set_per_page(int $selected_index): void {
+    function set_per_page($selected_index): void {
         $this->module('trongate_security');
         $this->trongate_security->_make_sure_allowed();
 
-        if (!is_numeric($selected_index)) {
-            $selected_index = $this->per_page_options[1];
-        }
-
-        $_SESSION['selected_per_page'] = $selected_index;
+        $_SESSION['selected_per_page'] = (int)$selected_index;
         redirect('trongate_pages/manage');
     }
 


### PR DESCRIPTION
As reported on the [Trongate Help Bar](https://trongate.io/help_bar_threads/display/MDnqCQ4rXkKwfYMd), user mjim found that when changing the _'Records Per Page'_ drop down to _'10'_ on _**'trongate_pages/manage'**_ it would trigger a type error because index 0 was being passed as an empty string.

This change fixes that problem by removing the _'int'_ type hinting and ensuring _'$selected_index'_ is always an integer when setting the index to the $_SESSION variable _'selected_per_page'_.

Also removed the if block, that was checking for _is_numeric()_, which is not needed and a was setting the wrong index from the default value of 20, which if invoked would throw an index error on the array.