### PR TITLE
fixed a Dynamic Property message on load() method

### DIFF
--- a/engine/Modules.php
+++ b/engine/Modules.php
@@ -5,6 +5,8 @@
  */
 class Modules {
 
+    private $modules = [];
+
     /**
      * Run a module's controller action.
      *
@@ -64,7 +66,7 @@ class Modules {
         }
 
         require_once $target_controller_path;
-        $this->$target_module = new $target_module($target_module);
+        $this->modules[$target_module] = new $target_module($target_module);
     }
 
     /**
@@ -74,7 +76,7 @@ class Modules {
      * @return array Returns an array containing the list of existing modules.
      */
     public function list(bool $recursive = false): array {
-        $target_path = APPPATH.'modules';
+        $target_path = APPPATH . 'modules';
         $file = new File;
         $existing_modules = $file->list_directory($target_path, $recursive);
         return $existing_modules;
@@ -103,5 +105,4 @@ class Modules {
 
         return $child_module;
     }
-
 }


### PR DESCRIPTION
Fix deprecation warning in Modules.php by using an array to store module instances

Resolves issue with dynamic property creation being deprecated in PHP 8.2 and later. 
Updated load method to use an array to store module instances, avoiding dynamic property creation. 
This change ensures compatibility with PHP 8.2 and later versions.
```
Deprecated
: Creation of dynamic property Modules::$trongate_pages is deprecated in
D:\xampp\htdocs\testapp\engine\Modules.php
on line
67
```
Tested on PHP 8.2.14, 8.2.19 and 8.3.7 (latest build of PHP) and is working fine with DC's new homepage update now using Trongate Pages 👍