### PR TITLE
Fix deprecation warnings and syntax highlighting issues in File_validation.php and Image.php

### DIFF
--- a/engine/File_validation.php
+++ b/engine/File_validation.php
@@ -66,11 +66,11 @@ class File_validation {
      * @param mixed $file_check_value The value or parameter associated with the check (e.g., allowed extensions, maximum size).
      * @param array $target_file The file array from $_FILES that contains file details like name and size.
      * @param string $temp_file_name The temporary filename of the file being uploaded.
-     * @param int $file_size The size of the file in kilobytes.
+     * @param float $file_size The size of the file in kilobytes.
      * @return mixed Returns the result of the validation check, which could be a boolean or a string containing an error message.
      * @throws Exception If an invalid validation rule key is provided.
      */
-    private function perform_check(string $file_check_key, $file_check_value, array $target_file, string $temp_file_name, int $file_size) {
+    private function perform_check(string $file_check_key, $file_check_value, array $target_file, string $temp_file_name, float $file_size) {
         $dimension_data = null;
         switch ($file_check_key) {
             case 'allowed_types':
@@ -137,11 +137,11 @@ class File_validation {
      * This function compares the size of a file against a predefined maximum size limit.
      * If the file size is greater than the allowed maximum, an error message is returned.
      *
-     * @param int $file_size The size of the file in kilobytes.
-     * @param int $max_size The maximum file size allowed in kilobytes.
+     * @param float $file_size The size of the file in kilobytes.
+     * @param float $max_size The maximum file size allowed in kilobytes.
      * @return string An error message if the file size exceeds the maximum allowed size; otherwise, an empty string.
      */
-    private function check_file_size(int $file_size, int $max_size): string {
+    private function check_file_size(float $file_size, float $max_size): string {
         if ($file_size > $max_size) {
             return 'The file that you attempted to upload exceeds the maximum allowed file size (' . $max_size . ' kilobytes).';
         }
@@ -203,5 +203,4 @@ class File_validation {
     public function get_target_file(): string {
         return array_keys($_FILES)[0];
     }
-
 }

--- a/engine/Image.php
+++ b/engine/Image.php
@@ -12,7 +12,7 @@ class Image {
 
     /**
      * Holds the GD image resource instance.
-     * @var resource|null
+     * @var resource|GdImage|null
      */
     private $image;
 
@@ -437,12 +437,12 @@ class Image {
      * for internal class operations and use by extending classes, supporting common image manipulations
      * such as scaling and cropping that require direct resizing.
      *
-     * @param int $width The target width for the resized image, must be a positive integer.
-     * @param int $height The target height for the resized image, must be a positive integer.
+     * @param float $width The target width for the resized image, must be a positive integer.
+     * @param float $height The target height for the resized image, must be a positive integer.
      * @throws Exception Throws an exception if the dimensions provided are invalid or if no image is loaded.
      * @return void
      */
-    protected function resize(int $width, int $height): void {
+    protected function resize(float $width, float $height): void {
         if ($this->image === null) {
             throw new Exception("No image is loaded to resize.");
         }
@@ -472,7 +472,7 @@ class Image {
      * alpha blending is disabled and alpha saving is enabled to maintain transparency in the resultant image.
      * This method is critical for preserving the visual integrity of images that require transparency.
      *
-     * @param resource $resource The image resource to which transparency settings should be applied.
+     * @param resource|GdImage $resource The image resource to which transparency settings should be applied.
      * @throws Exception Throws an exception if transparency preparation fails.
      * @return void
      */
@@ -656,7 +656,6 @@ class Image {
             throw new Not_found_exception($path);
         }
     }
-
 }
 
 /**


### PR DESCRIPTION
Addressed the following warnings and issues in File_validation.php and Image.php:

- PHP Deprecated: Implicit conversion from float to int
  - Changed type cast from int to float for **$file_size** and **$max_size**.
  - Changed type cast from int to float for **$width** and **$height**.

- Repaired PHP Intelephense syntax highlighting issues in Image.php:
  - Expected type 'GdImage'. Found 'resource|null'. intelephense(P1006)
    - Changed docblock to: * @var resource|**GdImage**|null
  - Expected type 'GdImage'. Found 'resource'. intelephense(P1006)
    - Changed docblock to: * @param resource|**GdImage** $resource
