### PR TITLE
'Error using trongate_administrators as the home page'

### DIFF
--- a/modules/trongate_administrators/views/tg_admin_template.php
+++ b/modules/trongate_administrators/views/tg_admin_template.php
@@ -11,7 +11,7 @@
 
 <body>
 	<?php
-	if ((segment(2) !== 'login') && (segment(2) !== 'submit_login')) { ?>
+	if ((segment(2) !== '') && (segment(2) !== 'login') && (segment(2) !== 'submit_login')) { ?>
 		<div id="top-gutter">
 			<div>
 				<a href="<?= BASE_URL ?>trongate_administrators/go_home">


### PR DESCRIPTION
Proposed bug fix for https://trongate.io/help_bar_threads/display/aQ3DRXGaQubahmPR

Added an additional condition in the view file. 

Now, in addition to the existing checks, if the 2nd URL segment is an empty string/not present, do not display the &lt;div> with ID "top-gutter".