### PR TITLE
Added modalClosed event to the closeModal() functions in admin.js and…

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -83,6 +83,9 @@ function closeModal() {
     if (overlay) {
       overlay.remove();
     }
+    // Dispatch a custom event indicating modal closure
+    var event = new Event('modalClosed', { bubbles: true, cancelable: true });
+    document.dispatchEvent(event);
   }
 }
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -82,6 +82,9 @@ function closeModal() {
     if (overlay) {
       overlay.remove();
     }
+    // Dispatch a custom event indicating modal closure
+    var event = new Event('modalClosed', { bubbles: true, cancelable: true });
+    document.dispatchEvent(event);
   }
 }
 


### PR DESCRIPTION
… app.js

Realised that it would be incredibly useful to be able to respond to the inbuilt Trongate Modal closing, but in order to do that it needs to emit an event.  This change provides that event and does so for people using both the public and or admin templates.

It requires that you actively subscribe to the event as early as possible.  Below is a good example of how to do so;

```js
  document.addEventListener('DOMContentLoaded', function () {
        document.addEventListener('modalClosed', function (event) {
            // Place your additional logic here
           
        });
    });
```

This means that you can now trigger additional functionality when a modal is closed.  Useful for anyone who needs it and will have zero impact on anyone who doesn't.