### PR TITLE
Configurable CORS for Api.php

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -23,3 +23,10 @@ define('DEFAULT_CONTROLLER', 'Welcome');
 define('DEFAULT_METHOD', 'index');
 define('MODULE_ASSETS_TRIGGER', '_module');
 define('INTERCEPT_404', 'trongate_pages/attempt_display');
+
+//Cross-Origin Resource Sharing (CORS)
+define('CORS_ENABLED', true);
+define('CORS_ALLOWED_ORIGINS', '*');
+define('CORS_ALLOWED_METHODS', 'GET, POST, PUT, DELETE, OPTIONS');
+define('CORS_ALLOWED_HEADERS', 'X-Requested-With, Content-Type, Origin, Authorization, Accept, Client-Security-Token, Accept-Encoding');
+define('CORS_ALLOWED_CREDENTIALS', true);

--- a/config/config.php
+++ b/config/config.php
@@ -16,7 +16,7 @@
 */
 
 //The main config file
-define('BASE_URL', '');
+define('BASE_URL', 'http://trongate-framework.test/');
 define('ENV', 'dev');
 define('DEFAULT_MODULE', 'welcome');
 define('DEFAULT_CONTROLLER', 'Welcome');
@@ -25,8 +25,8 @@ define('MODULE_ASSETS_TRIGGER', '_module');
 define('INTERCEPT_404', 'trongate_pages/attempt_display');
 
 //Cross-Origin Resource Sharing (CORS)
-define('CORS_ENABLED', true);
-define('CORS_ALLOWED_ORIGINS', '*');
-define('CORS_ALLOWED_METHODS', 'GET, POST, PUT, DELETE, OPTIONS');
-define('CORS_ALLOWED_HEADERS', 'X-Requested-With, Content-Type, Origin, Authorization, Accept, Client-Security-Token, Accept-Encoding');
-define('CORS_ALLOWED_CREDENTIALS', true);
+define('CORS_ENABLED', env(key: 'CORS_ENABLED', default: false));
+define('CORS_ALLOWED_ORIGINS', env(key: 'CORS_ALLOWED_ORIGINS', default: 'http://localhost, http://localhost:3000'));
+define('CORS_ALLOWED_METHODS', env(key: 'CORS_ALLOWED_METHODS', default: 'GET, POST, PUT, DELETE, OPTIONS, PATCH'));
+define('CORS_ALLOWED_HEADERS', env(key: 'CORS_ALLOWED_HEADERS', default: 'Trongatetoken, X-Requested-With, Content-Type, Origin, Authorization, Accept, Client-Security-Token, Accept-Encoding'));
+define('CORS_ALLOWED_CREDENTIALS', env(key: 'CORS_ALLOWED_CREDENTIALS', default: true));

--- a/engine/Api.php
+++ b/engine/Api.php
@@ -19,7 +19,7 @@ class Api extends Trongate {
             if (CORS_ALLOWED_ORIGINS === '*') {
                 header('Access-Control-Allow-Origin: *');
             } else {
-                if (isset($_SERVER['HTTP_ORIGIN']) && !empty($_SERVER['HTTP_ORIGIN'])) {
+                if (!empty($_SERVER['HTTP_ORIGIN'])) {
                     $origin = $_SERVER['HTTP_ORIGIN'];
                     $allowedOrigins = explode(',', CORS_ALLOWED_ORIGINS);
 
@@ -27,7 +27,7 @@ class Api extends Trongate {
                         header('Access-Control-Allow-Origin: ' . $origin);
                     } else {
                         $allowedOriginWildcards = array_filter($allowedOrigins, function($allowedOrigin) {
-                            return strpos($allowedOrigin, '*') !== false;
+                            return str_contains($allowedOrigin, '*');
                         });
 
                         if (count($allowedOriginWildcards) > 0) {
@@ -39,7 +39,7 @@ class Api extends Trongate {
                             $originHost = $originParts['host'];
 
                             foreach ($allowedOriginWildcards as $allowedOriginWildcard) {
-                                if (strpos($originHost, $allowedOriginWildcard) !== false) {
+                                if (str_contains($originHost, $allowedOriginWildcard)) {
                                     header('Access-Control-Allow-Origin: ' . $origin);
                                     return;
                                 }
@@ -50,8 +50,6 @@ class Api extends Trongate {
                     }
                 }
                 
-
-                header('Access-Control-Allow-Origin: ' . $origin);
                 header('Access-Control-Allow-Origin: ' . CORS_ALLOWED_ORIGINS);
             }
         }

--- a/engine/Api.php
+++ b/engine/Api.php
@@ -7,6 +7,66 @@ class Api extends Trongate {
     
     public function __construct() {
         parent::__construct();
+
+        if (defined('CORS_ENABLED') && CORS_ENABLED === true) {
+            $this->_define_cors_headers();
+        }
+    }
+
+    private function _define_cors_headers(): void
+    {
+        if (defined('CORS_ALLOWED_ORIGINS') && CORS_ALLOWED_ORIGINS !== '') {
+            if (CORS_ALLOWED_ORIGINS === '*') {
+                header('Access-Control-Allow-Origin: *');
+            } else {
+                if (isset($_SERVER['HTTP_ORIGIN']) && !empty($_SERVER['HTTP_ORIGIN'])) {
+                    $origin = $_SERVER['HTTP_ORIGIN'];
+                    $allowedOrigins = explode(',', CORS_ALLOWED_ORIGINS);
+
+                    if (in_array($origin, $allowedOrigins)) {
+                        header('Access-Control-Allow-Origin: ' . $origin);
+                    } else {
+                        $allowedOriginWildcards = array_filter($allowedOrigins, function($allowedOrigin) {
+                            return strpos($allowedOrigin, '*') !== false;
+                        });
+
+                        if (count($allowedOriginWildcards) > 0) {
+                            $allowedOriginWildcards = array_map(function($allowedOrigin) {
+                                return str_replace('*', '', $allowedOrigin);
+                            }, $allowedOriginWildcards);
+
+                            $originParts = parse_url($origin);
+                            $originHost = $originParts['host'];
+
+                            foreach ($allowedOriginWildcards as $allowedOriginWildcard) {
+                                if (strpos($originHost, $allowedOriginWildcard) !== false) {
+                                    header('Access-Control-Allow-Origin: ' . $origin);
+                                    return;
+                                }
+                            }
+                        }
+
+                        header('Access-Control-Allow-Origin: ' . $allowedOrigins[0]);
+                    }
+                }
+                
+
+                header('Access-Control-Allow-Origin: ' . $origin);
+                header('Access-Control-Allow-Origin: ' . CORS_ALLOWED_ORIGINS);
+            }
+        }
+
+        if (defined('CORS_ALLOWED_METHODS') && CORS_ALLOWED_METHODS !== '') {
+            header('Access-Control-Allow-Methods: ' . CORS_ALLOWED_METHODS);
+        }
+
+        if (defined('CORS_ALLOWED_HEADERS') && CORS_ALLOWED_HEADERS !== '') {
+            header('Access-Control-Allow-Headers: ' . CORS_ALLOWED_HEADERS);
+        }
+
+        if (defined('CORS_ALLOWED_CREDENTIALS')) {
+            header('Access-Control-Allow-Credentials: ' . CORS_ALLOWED_CREDENTIALS ? 'true' : 'false');
+        }
     }
 
     /**

--- a/engine/Api.php
+++ b/engine/Api.php
@@ -15,43 +15,19 @@ class Api extends Trongate {
 
     private function _define_cors_headers(): void
     {
-        if (defined('CORS_ALLOWED_ORIGINS') && CORS_ALLOWED_ORIGINS !== '') {
-            if (CORS_ALLOWED_ORIGINS === '*') {
-                header('Access-Control-Allow-Origin: *');
-            } else {
-                if (!empty($_SERVER['HTTP_ORIGIN'])) {
-                    $origin = $_SERVER['HTTP_ORIGIN'];
-                    $allowedOrigins = explode(',', CORS_ALLOWED_ORIGINS);
+        if (
+            defined('CORS_ALLOWED_ORIGINS')
+            && CORS_ALLOWED_ORIGINS !== ''
+            && !empty($_SERVER['HTTP_ORIGIN'])
+        ) {
+            $origin = $_SERVER['HTTP_ORIGIN'];
+            $allowedOrigins = explode(',', CORS_ALLOWED_ORIGINS);
 
-                    if (in_array($origin, $allowedOrigins)) {
-                        header('Access-Control-Allow-Origin: ' . $origin);
-                    } else {
-                        $allowedOriginWildcards = array_filter($allowedOrigins, function($allowedOrigin) {
-                            return str_contains($allowedOrigin, '*');
-                        });
-
-                        if (count($allowedOriginWildcards) > 0) {
-                            $allowedOriginWildcards = array_map(function($allowedOrigin) {
-                                return str_replace('*', '', $allowedOrigin);
-                            }, $allowedOriginWildcards);
-
-                            $originParts = parse_url($origin);
-                            $originHost = $originParts['host'];
-
-                            foreach ($allowedOriginWildcards as $allowedOriginWildcard) {
-                                if (str_contains($originHost, $allowedOriginWildcard)) {
-                                    header('Access-Control-Allow-Origin: ' . $origin);
-                                    return;
-                                }
-                            }
-                        }
-
-                        header('Access-Control-Allow-Origin: ' . $allowedOrigins[0]);
-                    }
-                }
-                
-                header('Access-Control-Allow-Origin: ' . CORS_ALLOWED_ORIGINS);
+            if (in_array($origin, $allowedOrigins)) {
+                header('Access-Control-Allow-Origin: ' . $origin);
             }
+
+            header('Access-Control-Allow-Origin: ' . CORS_ALLOWED_ORIGINS);
         }
 
         if (defined('CORS_ALLOWED_METHODS') && CORS_ALLOWED_METHODS !== '') {

--- a/engine/Api.php
+++ b/engine/Api.php
@@ -15,32 +15,15 @@ class Api extends Trongate {
 
     private function _define_cors_headers(): void
     {
-        if (
-            defined('CORS_ALLOWED_ORIGINS')
-            && CORS_ALLOWED_ORIGINS !== ''
-            && !empty($_SERVER['HTTP_ORIGIN'])
-        ) {
-            $origin = $_SERVER['HTTP_ORIGIN'];
-            $allowedOrigins = explode(',', CORS_ALLOWED_ORIGINS);
+        require_once __DIR__ . '/Cors.php';
+        $cors = new Cors(
+            allowedOriginsString: CORS_ALLOWED_ORIGINS,
+            allowedMethodsString: CORS_ALLOWED_METHODS,
+            allowedHeadersString: CORS_ALLOWED_HEADERS,
+            allowedCredentials: CORS_ALLOWED_CREDENTIALS
+        );
 
-            if (in_array($origin, $allowedOrigins)) {
-                header('Access-Control-Allow-Origin: ' . $origin);
-            }
-
-            header('Access-Control-Allow-Origin: ' . CORS_ALLOWED_ORIGINS);
-        }
-
-        if (defined('CORS_ALLOWED_METHODS') && CORS_ALLOWED_METHODS !== '') {
-            header('Access-Control-Allow-Methods: ' . CORS_ALLOWED_METHODS);
-        }
-
-        if (defined('CORS_ALLOWED_HEADERS') && CORS_ALLOWED_HEADERS !== '') {
-            header('Access-Control-Allow-Headers: ' . CORS_ALLOWED_HEADERS);
-        }
-
-        if (defined('CORS_ALLOWED_CREDENTIALS')) {
-            header('Access-Control-Allow-Credentials: ' . CORS_ALLOWED_CREDENTIALS ? 'true' : 'false');
-        }
+        $cors->defineHeaders($_SERVER['HTTP_ORIGIN']);
     }
 
     /**

--- a/engine/Cors.php
+++ b/engine/Cors.php
@@ -1,0 +1,130 @@
+<?php
+
+class Cors
+{
+    const ALLOWED_ORIGINS = 'Access-Control-Allow-Origin';
+    const ALLOWED_METHODS = 'Access-Control-Allow-Methods';
+    const ALLOWED_HEADERS = 'Access-Control-Allow-Headers';
+    const ALLOWED_CREDENTIALS = 'Access-Control-Allow-Credentials';
+
+    protected array $allowedOrigins = [];
+    protected array $allowedOriginsPatterns = [];
+
+    public function __construct(
+        protected string $allowedOriginsString = '',
+        protected string $allowedMethodsString = '',
+        protected string $allowedHeadersString = '',
+        protected bool $allowedCredentials = false
+    ) {
+        $this->gatherAllowedOrigins();
+        $this->setAllowedMethods();
+        $this->setAllowedHeaders();
+    }
+
+    public function defineHeaders(string $origin): void
+    {
+        $headers = $this->match($origin);
+
+        foreach ($headers as $header => $value) {
+            header(sprintf('%s: %s', $header, $value));
+        }
+    }
+
+    public function match(string $origin): array
+    {
+        $headers = [
+            self::ALLOWED_HEADERS => $this->allowedHeadersString,
+            self::ALLOWED_METHODS => $this->allowedMethodsString,
+        ];
+
+        if ($matchedOrigin = $this->matchOrigin($origin)) {
+            $headers[self::ALLOWED_ORIGINS] = $matchedOrigin;
+
+            if ($this->allowedCredentials) {
+                $headers[self::ALLOWED_CREDENTIALS] = 'true';
+            }
+        }
+
+        return $headers;
+    }
+
+    private function matchOrigin(string $origin): ?string
+    {
+        // Exact match
+        if (in_array($origin, $this->allowedOrigins)) {
+            return $origin;
+        }
+
+        // Wildcard pattern match
+        foreach ($this->allowedOriginsPatterns as $pattern) {
+            if (preg_match($pattern, $origin)) {
+                return $origin;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Gathers the provided allowed origins string and converts it to an array of exact origins and wildcard patterns.
+     *
+     * @return void
+     */
+    private function gatherAllowedOrigins(): void
+    {
+        if (!empty($this->allowedOriginsString)) {
+            $this->allowedOrigins = explode(',', $this->allowedOriginsString);
+
+            foreach ($this->allowedOrigins as $origin) {
+                if (str_contains($origin, '*')) {
+                    $this->allowedOriginsPatterns[] = $this->convertWildcardToPattern($origin);
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Convert a wildcard pattern to a valid regex pattern.
+     * e.g. "*.example.com" is converted to "#^.*\.example\.com\z#u"
+     * which matches "www.example.com", "sub.example.com", "example.com", etc.
+     *
+     * @param string $pattern
+     * @return string
+     */
+    private function convertWildcardToPattern(string $pattern): string
+    {
+        $pattern = preg_quote($pattern, '#');
+
+        // Asterisks are translated into zero-or-more regular expression wildcards
+        // to make it convenient to check if the strings starts with the given
+        // pattern such as "*.example.com", making any string check convenient.
+        $pattern = str_replace('\*', '.*', $pattern);
+
+        return '#^' . $pattern . '\z#u';
+    }
+
+    private function setAllowedMethods(): void
+    {
+        if (!empty($this->allowedMethodsString)) {
+            header(
+                sprintf(
+                    'Access-Control-Allow-Methods: %s',
+                    $this->allowedMethodsString
+                )
+            );
+        }
+    }
+
+    private function setAllowedHeaders(): void
+    {
+        if (!empty($this->allowedHeadersString)) {
+            header(
+                sprintf(
+                    'Access-Control-Allow-Headers: %s',
+                    $this->allowedHeadersString
+                )
+            );
+        }
+    }
+}

--- a/engine/tg_helpers/utilities_helper.php
+++ b/engine/tg_helpers/utilities_helper.php
@@ -1,4 +1,15 @@
 <?php
+function env(string $key, mixed $default = null): mixed
+{
+    $value = getenv($key);
+
+    if ($value === false) {
+        return $default;
+    }
+
+    return $value;
+}
+
 /**
  * Outputs the given data as JSON in a prettified format, suitable for debugging and visualization.
  * This function is especially useful during development for inspecting data structures in a readable JSON format directly in the browser. 


### PR DESCRIPTION
Noticed there was a question on the help_bar regarding CORS support for clients consuming the API endpoints.

This feature adds support for defining domains including wildcard matching and restricting allowed headers & http methods in the config/config.php file.