### PR TITLE
Fix to Core.php to permit serving child module assets

### DIFF
--- a/engine/File.php
+++ b/engine/File.php
@@ -212,8 +212,8 @@ class File {
     public function write(string $file_path, $data, bool $append = false): bool {
 
         // Validate the path to ensure it's allowed based on predefined security rules
-        if (!$this->is_path_valid($directory_path)) {
-            throw new Exception("Access to this path is restricted: $directory_path");
+        if (!$this->is_path_valid($file_path)) {
+            throw new Exception("Access to this file is restricted: $file_path");
         }
 
         $flags = $append ? FILE_APPEND : 0;


### PR DESCRIPTION
File.php : correct variable names in write() function.

Core.php:

The new sanitize_file_path() function prevents child module assets from being found. 

This modification fixes that issue and returns the child module asset path, making the serve_child_module_asset() function redundant so a good chunk of code can be removed from Core.php

I've added a boolean variable $is_child_module to sanitize_file_path() so that we can loop back, setting it to true to check the path to a child module asset if nothing's found in the parent module.

I've also added a 404 http response code if the file path is invalid. 