### PR TITLE
fix form_helper and fixes infinite-scroll.js

### DIFF
--- a/engine/tg_helpers/form_helper.php
+++ b/engine/tg_helpers/form_helper.php
@@ -381,7 +381,7 @@ function form_dropdown(string $name, array $options, ?string $selected_key = nul
 
     foreach ($options as $option_key => $option_value) {
         $option_attributes = ['value' => $option_key];
-        if ($option_key === $selected_key) {
+        if ($option_key == $selected_key) {
             $option_attributes['selected'] = 'selected';
         }
         $html .= '    <option' . get_attributes_str($option_attributes) . '>' 

--- a/public/js/infinite-scroll.js
+++ b/public/js/infinite-scroll.js
@@ -115,8 +115,9 @@ function loadMoreRecords() {
             const newRows = (containerType === 'table') ? foundPaginationContainer.querySelectorAll('tbody tr') : foundPaginationContainer.children;
 
             // Append the new rows to the paginationRowsContainer
+            const paginationRowsContainer = (containerType === 'table') ? paginationContainer.querySelector('tbody') : paginationContainer;
             newRows.forEach(row => {
-                paginationContainer.appendChild(row);
+                paginationRowsContainer.appendChild(row);
             });
 
             // Swap the pagination on the existing page.


### PR DESCRIPTION
**fix form_helper :** 
fixes form_dropdown function to correctly take into account the choice of the key of the selected option

**fix infinite-scroll.js :** 
fixes a bug because if the element is a table, new rows were inserted as children of the table element instead of the tbody element