### PR TITLE
Efficiency improvements to serve_module_asset()

### DIFF
--- a/engine/Model.php
+++ b/engine/Model.php
@@ -34,7 +34,7 @@ class Model {
         $this->port = (defined('PORT') ? PORT : '3306');
         $this->current_module = $current_module;
 
-        $dsn = 'mysql:host=' . $this->host . ';port=' . $this->port . ';dbname=' . $this->dbname;
+        $dsn = 'mysql:host=' . $this->host . ';port=' . $this->port . ';dbname=' . $this->dbname . ';charset=utf8mb4';
         $options = array(
             PDO::ATTR_PERSISTENT => true,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION

--- a/engine/Model.php
+++ b/engine/Model.php
@@ -34,7 +34,7 @@ class Model {
         $this->port = (defined('PORT') ? PORT : '3306');
         $this->current_module = $current_module;
 
-        $dsn = 'mysql:host=' . $this->host . ';port=' . $this->port . ';dbname=' . $this->dbname . ';charset=utf8mb4';
+        $dsn = 'mysql:host=' . $this->host . ';port=' . $this->port . ';dbname=' . $this->dbname . ';charset=' . $this->charset;
         $options = array(
             PDO::ATTR_PERSISTENT => true,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION


### PR DESCRIPTION
Some efficiency improvements when serving module assets - helpful when dealing with larger files.

1) readfile() vs file_get_contents() streams larger files and avoids the need to read the whole file into memory first. 

2) added 304 Not Modified response to HTTP_IF_MODIFIED_SINCE request. Avoids having to send files if client just wants to check that their cached copy is still valid.

3) is_file() checks if it's a valid file vs file_exists() which returns true for files and directories

4) 403 response code to .php and api.json files is the more common response to attempts to access files that shouldn't be

5) Add Last-Modified header when sending file