### PR TITLE
Fix module relations panel empty-state note when associations exist

### DIFF
--- a/modules/module_relations/Module_relations.php
+++ b/modules/module_relations/Module_relations.php
@@ -498,7 +498,10 @@ class Module_relations extends Trongate {
      * hold at most one partner, so replacing it is remove-then-add rather
      * than picking a second option alongside the first. For every relation
      * type, the form is also hidden when there are simply no available
-     * options left to pick from.
+     * options left to pick from. The view's empty-state paragraph ("no …
+     * records available") is shown only when the calling record has no
+     * existing associations AND no options are available — a record that
+     * already has associated items needs no "nothing to assign" notice.
      *
      * @param array  $settings       The decoded relation settings array.
      * @param string $calling_module The module whose panel this is.

--- a/modules/module_relations/views/panel_body.php
+++ b/modules/module_relations/views/panel_body.php
@@ -14,15 +14,22 @@
  *                                       (at least one option available,
  *                                       and for one-to-one relations no
  *                                       association existing yet). When no
- *                                       option is available at all, the
- *                                       region holds an empty-state
- *                                       paragraph instead: "There are
- *                                       currently no … records available to
- *                                       assign to this …" — or, when the
- *                                       relation settings carry no record
- *                                       names, the generic "No records are
- *                                       currently available for
- *                                       assignment."
+ *                                       option is available at all AND the
+ *                                       calling record has no existing
+ *                                       associations, the region holds an
+ *                                       empty-state paragraph instead:
+ *                                       "There are currently no … records
+ *                                       available to assign to this …" —
+ *                                       or, when the relation settings
+ *                                       carry no record names, the generic
+ *                                       "No records are currently
+ *                                       available for assignment." A
+ *                                       record that already has
+ *                                       associations gets no such notice
+ *                                       (its items are listed in the
+ *                                       region below); nothing is left to
+ *                                       assign, so the region is simply
+ *                                       empty.
  *   #rel-{panel_id}-associated-items  — the associated-items list; an
  *                                       empty region when none exist (no
  *                                       placeholder paragraph).
@@ -81,7 +88,7 @@ $oob_swaps = json_encode([
                 <button type="submit" class="associate-form__submit">Add</button>
             </div>
         </form>
-    <?php elseif (count($available_options) === 0): ?>
+    <?php elseif ((count($available_options) === 0) && (count($associated_rows) === 0)): ?>
         <?php if (($associated_singular !== '') && ($calling_singular !== '')): ?>
             <p class="associate-form__empty">There are currently no <?= out(str_replace('_', ' ', $associated_singular)) ?> records available to assign to this <?= out(str_replace('_', ' ', $calling_singular)) ?>.</p>
         <?php else: ?>


### PR DESCRIPTION
Ports the fix from [trongate/module_relations_build@4e2e23c](https://github.com/trongate/module_relations_build/commit/4e2e23c), resolving [trongate/module_relations_build#25](https://github.com/trongate/module_relations_build/issues/25).

**Problem:** on a show-page summary panel, the note *"There are currently no {child} records available to assign to this {parent}."* rendered whenever the add dropdown had no options left — even when the record already held one or more associations. A one-to-many customer whose every order was already claimed saw the note sitting directly above its own list of orders.

**Fix:** in `modules/module_relations/views/panel_body.php`, the empty-state note now renders only when the record has **no existing associations AND no options available**. A record that already has associated items simply shows its list, with the associate-form region left empty. The one shared view serves every relationship type, so the rule applies uniformly to one-to-one, one-to-many, and many-to-many.

**Verified** (dev app, full state matrix):
- association(s) present + pool empty → no note, items listed
- no associations + pool empty → note shown
- association(s) present + options available → add form shown
- no associations + options available → add form shown

Files changed are byte-identical to the upstream fix (framework tree already carries the two by-design docblock differences from #262 review). No CHANGELOG touch — per release convention, the next release PR logs it.